### PR TITLE
to a 3D model file in one of the supported formats (STL, OBJ, etc.).

### DIFF
--- a/generate_image()3d
+++ b/generate_image()3d
@@ -1,0 +1,20 @@
+import trimesh
+
+def convert_to_3d(image, output_file, format='stl'):
+    # Convert the PIL image to a numpy array
+    image_array = np.array(image)
+
+    # Convert the numpy array to a trimesh mesh
+    mesh = trimesh.Trimesh(vertices=[], faces=[], face_colors=[], vertex_colors=[], normals=[], metadata={})
+    mesh.vertices = trimesh.creation.camera_transform(points=image_array, camera_transforms=None, resolution=image_array.shape[:2])
+    mesh.faces = trimesh.creation.triangulate_quads(mesh.faces)
+
+    # Export the mesh to the specified file format
+    if format == 'stl':
+        mesh.export(output_file)
+    elif format == 'obj':
+        mesh.export(output_file, file_type='obj')
+    elif format == 'ply':
+        mesh.export(output_file, file_type='ply')
+    else:
+        raise ValueError('Invalid output file format. Please choose either "stl", "obj", or "ply".')


### PR DESCRIPTION
This function takes a PIL image generated by generate_image() and an output file path for the 3D model file. It also takes an optional format argument that specifies the output file format ('stl', 'obj', or 'ply').

The function first converts the PIL image to a numpy array and then creates a trimesh mesh using the camera_transform() and triangulate_quads() functions from the trimesh library. Finally, it exports the mesh to the specified file format using the export() function from the trimesh library.

You can use this function after calling generate_image() to convert the generated image to a 3D model file that can be printed using a 3D printer. For example:

# Generate an image using StyleGAN2-ADA
image = generate_image('A red cube on a white table', model_type='StyleGAN2-ADA')

# Convert the image to a 3D model file in STL format convert_to_3d(image, 'output.stl', format='stl')