### PR TITLE
To set the maximum file size limit, you can use the app.config object…

### DIFF
--- a/app.config
+++ b/app.config
@@ -1,0 +1,1 @@
+app.config['MAX_CONTENT_LENGTH'] = 10 * 1024 * 1024


### PR DESCRIPTION
… in Flask to set the MAX_CONTENT_LENGTH attribute to the desired size in bytes.

 For example, to set a maximum file size of 10 megabytes (10 * 1024 * 1024 bytes), you can add the following line to your Flask app configuration:

This will limit the file size of any file uploaded through your app to 10 megabytes or less. If a user attempts to upload a file larger than this limit, Flask will automatically return a 413 HTTP error response.

It's important to note that setting a maximum file size limit is not a foolproof solution for preventing large file uploads, as it can be bypassed by malicious users or by other means. Therefore, it's important to implement other security measures and to validate user input in your application to ensure that only valid and safe files are uploaded.